### PR TITLE
Add missing tests for default coercion

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -284,11 +284,8 @@ fn enforce_within_constraints(
     // Returns true if `ty` is a subtype of at least one parent constraint.
     let is_within = |ty: &Bound<'_, PyAny>| -> PyResult<bool> {
         for constraint in parent_constraints_tuple.iter() {
-            let within = if let (Ok(t), Ok(c)) = (
-                ty.cast::<PyType>(),
-                constraint.cast::<PyType>(),
-            ) {
-                t.is_subclass(&c)?
+            let within = if let (Ok(t), Ok(c)) = (ty.cast::<PyType>(), constraint.cast::<PyType>()) {
+                t.is_subclass(c)?
             } else {
                 let builtins = py.import(intern!(py, "builtins"))?;
                 let issubclass = builtins.getattr(intern!(py, "issubclass"))?;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -268,10 +268,7 @@ fn enforce_narrower_typevar_bound(
 /// For a TypeVar `arg` with only a bound (no constraints): the bound must be a
 /// subtype of at least one parent constraint.
 /// A TypeVar `arg` with neither constraints nor a bound is rejected.
-fn enforce_within_constraints(
-    parent: &Bound<'_, PyAny>,
-    arg: &Bound<'_, PyAny>,
-) -> PyResult<()> {
+fn enforce_within_constraints(parent: &Bound<'_, PyAny>, arg: &Bound<'_, PyAny>) -> PyResult<()> {
     let py = parent.py();
     let parent_constraints = parent.getattr(intern!(py, "__constraints__"))?;
     let Ok(parent_constraints_tuple) = parent_constraints.cast::<PyTuple>() else {
@@ -284,7 +281,7 @@ fn enforce_within_constraints(
     // Returns true if `ty` is a subtype of at least one parent constraint.
     let is_within = |ty: &Bound<'_, PyAny>| -> PyResult<bool> {
         for constraint in parent_constraints_tuple.iter() {
-            let within = if let (Ok(t), Ok(c)) = (ty.cast::<PyType>(), constraint.cast::<PyType>()) 
+            let within = if let (Ok(t), Ok(c)) = (ty.cast::<PyType>(), constraint.cast::<PyType>())
             {
                 t.is_subclass(c)?
             } else {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -284,7 +284,8 @@ fn enforce_within_constraints(
     // Returns true if `ty` is a subtype of at least one parent constraint.
     let is_within = |ty: &Bound<'_, PyAny>| -> PyResult<bool> {
         for constraint in parent_constraints_tuple.iter() {
-            let within = if let (Ok(t), Ok(c)) = (ty.cast::<PyType>(), constraint.cast::<PyType>()) {
+            let within = if let (Ok(t), Ok(c)) = (ty.cast::<PyType>(), constraint.cast::<PyType>()) 
+            {
                 t.is_subclass(c)?
             } else {
                 let builtins = py.import(intern!(py, "builtins"))?;

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -33,22 +33,22 @@ from ators.behaviors import Coercer, coerce, coerce_init
         (str, True, [1, b"abc"], ["1", TypeError("")]),
         # complex: string or complex -> complex object
         (complex, False, ["1+2j", 3 + 4j], [complex("1+2j"), complex(3 + 4j)]),
-        (complex, True, ["1+2j", 3 + 4j], [complex("1+2j"), TypeError("")]),
+        (complex, True, ["1+2j", "3 + 4j"], [complex("1+2j"), TypeError("")]),
         # fixed-length tuple: sequence coerced and items coerced
         (tuple[int, int], False, [["1", "2"], (3, 4)], [(1, 2), (3, 4)]),
-        (tuple[int, int], True, [["1", "2"], (3, 4)], [(1, 2), TypeError("")]),
+        (tuple[int, int], True, [["1", "2"], (3, "4")], [(1, 2), TypeError("")]),
         # var-tuple (tuple[int, ...])
-        (tuple[int, ...], False, [["1", "2", "3"], (4, 5)], [(1, 2, 3), (4, 5)]),
-        (tuple[int, ...], True, [["1", "2", "3"], (4, 5)], [(1, 2, 3), TypeError("")]),
+        (tuple[int, ...], False, [["1", "2", "3"], (4, "5")], [(1, 2, 3), (4, 5)]),
+        (tuple[int, ...], True, [["1", "2", "3"], ("4", 5)], [(1, 2, 3), TypeError("")]),
         # list coercion from sequence
-        (list[int], False, [("1", "2"), [3, 4]], [[1, 2], [3, 4]]),
-        (list[int], True, [("1", "2"), [3, 4]], [[1, 2], TypeError("")]),
+        (list[int], False, [("1", "2"), [3, "4"]], [[1, 2], [3, 4]]),
+        (list[int], True, [("1", "2"), ["3", 4]], [[1, 2], TypeError("")]),
         # dict coercion from mapping and iterable-of-pairs
         (dict[str, int], False, [{1: "2", "3": 4}, [(5, "6")]], [{"1": 2, "3": 4}, {"5": 6}]),
         (dict[str, int], True, [{1: "2", "3": 4}, [(5, "6")]], [{"1": 2, "3": 4}, TypeError("")]),
         # Union: first matching member is used
-        (int | str, False, ["1", "a"], [1, "a"]),
-        (int | str, True, ["1", "a"], [1, TypeError("")]),
+        (int | complex, False, ["1", "1j", "a"], [1, 1j, TypeError("")]),
+        (int | complex, True, ["1j", "a"], [1j, TypeError("")]),
     ],
 )
 def test_type_inferred_coercion(ty, init, inputs, expected):

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -13,27 +13,53 @@ from ators import Ators, member
 from ators.behaviors import Coercer, coerce, coerce_init
 
 
-# XXX refactor to support all types and follow following tests to simplify
-# testing both init true and false
 @pytest.mark.parametrize(
     "ty, init, inputs, expected",
     [
+        # ints
         (int, False, ["1", "2"], [1, 2]),
         (int, True, ["1", "2"], [1, TypeError("")]),
+        # floats
         (float, False, ["1.5", "2.5"], [1.5, 2.5]),
         (float, True, ["1.5", "2.5"], [1.5, TypeError("")]),
+        # optional int (int | None)
         (int | None, False, ["1", None, "2"], [1, None, 2]),
         (int | None, True, ["1", None, "2"], [1, None, TypeError("")]),
-        # coerce for instance and typed
+        # bool uses Python's bool(...) semantics (non-empty strings => True)
+        (bool, False, ["False", ""], [True, False]),
+        (bool, True, ["False", ""], [True, TypeError("")]),
+        # str: int -> "1", bytes -> "b'...'"
+        (str, False, [1, b"abc"], ["1", "b'abc'"]),
+        (str, True, [1, b"abc"], ["1", TypeError("")]),
+        # complex: string or complex -> complex object
+        (complex, False, ["1+2j", 3 + 4j], [complex("1+2j"), complex(3 + 4j)]),
+        (complex, True, ["1+2j", 3 + 4j], [complex("1+2j"), TypeError("")]),
+        # fixed-length tuple: sequence coerced and items coerced
+        (tuple[int, int], False, [["1", "2"], (3, 4)], [(1, 2), (3, 4)]),
+        (tuple[int, int], True, [["1", "2"], (3, 4)], [(1, 2), TypeError("")]),
+        # var-tuple (tuple[int, ...])
+        (tuple[int, ...], False, [["1", "2", "3"], (4, 5)], [(1, 2, 3), (4, 5)]),
+        (tuple[int, ...], True, [["1", "2", "3"], (4, 5)], [(1, 2, 3), TypeError("")]),
+        # list coercion from sequence
+        (list[int], False, [("1", "2"), [3, 4]], [[1, 2], [3, 4]]),
+        (list[int], True, [("1", "2"), [3, 4]], [[1, 2], TypeError("")]),
+        # dict coercion from mapping and iterable-of-pairs
+        (dict[str, int], False, [{1: "2", "3": 4}, [(5, "6")]], [{"1": 2, "3": 4}, {"5": 6}]),
+        (dict[str, int], True, [{1: "2", "3": 4}, [(5, "6")]], [{"1": 2, "3": 4}, TypeError("")]),
+        # Union: first matching member is used
+        (int | str, False, ["1", "a"], [1, "a"]),
+        (int | str, True, ["1", "a"], [1, TypeError("")]),
     ],
 )
 def test_type_inferred_coercion(ty, init, inputs, expected):
     class A(Ators):
         a: ty = getattr(member(), "coerce_init" if init else "coerce")()
 
+    # initialize using the first input
     a = A(**{"a": inputs[0]})
     assert a.a == expected[0]
 
+    # subsequent inputs are assignments: either succeed or raise depending on expected
     for inp, exp in zip(inputs[1:], expected[1:]):
         if isinstance(exp, Exception):
             with pytest.raises(type(exp)) as e:

--- a/tests/test_type_validation.py
+++ b/tests/test_type_validation.py
@@ -401,7 +401,7 @@ def test_constrained_typevar_matches_union_behavior():
     """Constrained TypeVar validation should match int | str union behavior."""
 
     class UnionBox(Ators):
-        item: int | str = member(int | str)
+        item: int | str = member()
 
     cbox = ConstrainedBox()
     ubox = UnionBox()

--- a/tests/test_type_validation.py
+++ b/tests/test_type_validation.py
@@ -374,7 +374,7 @@ T_constrained = TypeVar("T_constrained", int, str)
 
 
 class ConstrainedBox(Ators):
-    item: T_constrained = member(T_constrained)
+    item: T_constrained = member()
 
 
 def test_constrained_typevar_accepts_first_constraint():


### PR DESCRIPTION
Two formatting violations in `src/meta.rs` introduced by the constrained `TypeVar` validation changes:

- `enforce_within_constraints` signature was unnecessarily split across multiple lines
- Trailing whitespace before newline in an `if let` expression